### PR TITLE
feat: sources/destinations CRUD support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.github
+.vscode

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @soumyadebm
+* @fxenik

--- a/README.md
+++ b/README.md
@@ -18,21 +18,68 @@
 
 ---
 
-# \*\*Repo Name\*\*
+# Rudder API SDK - Go
 
-\*\*Repo description\*\*
+A Golang SDK implementation for the Rudder Public API.
 
 ## Overview
 
-\*\*Describe what the software does.\*\*
+This library can be used to interface with Rudder Public API v2. Initially, it will support CRUD operations
+for common Rudder resources (e.g Sources, Destinations, Connections). Eventually, additional support will be added
+for any features available by Rudder Public API.
+
+  **This library, as well as Rudder Public API v2, is still in experimental alpha stage. Although we design for long-term backwards compatibility support in mind, some breaking changes are expected at this point.**
 
 ## Features
 
-\*\*Describe the key features, if necessary.\*\*
+* Supports CRUD operations for Sources and Destinations
 
 ## Getting started
 
-\*\*Describe how to use the software.\*\*
+```Golang
+// create a client
+c, err := client.New("my-access-token")
+
+// check for any errors
+if err != nil {
+  return err
+}
+
+// fetch a Source by ID
+src, err := c.Sources.Get(context.Background(), "some-id")
+
+// list all Sources
+page, err := c.Sources.List(context.Background())
+if err == nil {
+  return err  
+}
+for page != nil {
+  fmt.Println(page.Sources)
+  page, err = c.Sources.Next(context.Background(), page.Paging)
+  if err != nil {
+    return err
+  }
+}
+
+// create a new Destination
+dst, err := c.Destinations.Create(context.Background(), &Destination{
+  Type: 'POSTGRES',
+  Name: 'my postgres',
+  Config: json.RawMessage(`{
+    "host": "example.com",
+    "username": "rudder",
+    "password": "some secret",
+    "port": "5432"
+  }`)
+})
+
+// check the error
+if apierr, ok := err.(*client.APIError); ok {
+  fmt.Println("status code:", apierr.HTTPStatusCode)
+  fmt.Println("error message:", apierr.Message)
+  return apierr
+}
+```
 
 ## Contribute
 
@@ -40,4 +87,4 @@ We would love to see you contribute to RudderStack. Get more information on how 
 
 ## License
 
-The RudderStack \*\*software name\*\* is released under the [**MIT License**](https://opensource.org/licenses/MIT).
+The RudderStack API Go SDK is released under the [**MIT License**](https://opensource.org/licenses/MIT).

--- a/client/client.go
+++ b/client/client.go
@@ -1,0 +1,101 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+type HTTPClient interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+type Client struct {
+	baseURL     string
+	accessToken string
+	httpClient  HTTPClient
+
+	Sources      *sources
+	Destinations *destinations
+}
+
+const BASE_URL_V2 = "https://api.rudderstack.com/v2"
+
+var (
+	ErrEmptyAccessToken  = fmt.Errorf("access token cannot be empty")
+	ErrInvalidBaseURL    = fmt.Errorf("base url cannot be empty")
+	ErrInvalidHTTPClient = fmt.Errorf("http client cannot be nil")
+)
+
+func New(accessToken string, options ...Option) (*Client, error) {
+	client := &Client{
+		baseURL:     BASE_URL_V2,
+		httpClient:  &http.Client{},
+		accessToken: accessToken,
+	}
+
+	client.Sources = &sources{service: client.service("sources")}
+	client.Destinations = &destinations{service: client.service("destinations")}
+
+	for _, o := range options {
+		if err := o(client); err != nil {
+			return nil, err
+		}
+	}
+
+	if client.accessToken == "" {
+		return nil, ErrEmptyAccessToken
+	}
+
+	return client, nil
+}
+
+func (c *Client) URL(path string) string {
+	if len(path) == 0 {
+		return c.baseURL
+	}
+
+	return fmt.Sprintf("%s/%s", c.baseURL, strings.TrimPrefix(path, "/"))
+}
+
+func (c *Client) Do(ctx context.Context, method, path string, body io.Reader) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, method, c.URL(path), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("User-Agent", "terraform-provider-rudderstack/v0")
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.accessToken))
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	data, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	// check if response has an error status code and parse API error accordingly
+	if res.StatusCode < 200 || res.StatusCode > 299 {
+		apiError := &APIError{HTTPStatusCode: res.StatusCode}
+		err := json.Unmarshal(data, apiError)
+		if err != nil {
+			return nil, err
+		}
+
+		return nil, apiError
+	}
+
+	return data, nil
+}
+
+func (c *Client) service(basePath string) *service {
+	return &service{client: c, basePath: basePath}
+}

--- a/client/client.go
+++ b/client/client.go
@@ -17,6 +17,7 @@ type HTTPClient interface {
 type Client struct {
 	baseURL     string
 	accessToken string
+	userAgent   string
 	httpClient  HTTPClient
 
 	Sources      *sources
@@ -36,6 +37,7 @@ func New(accessToken string, options ...Option) (*Client, error) {
 		baseURL:     BASE_URL_V2,
 		httpClient:  &http.Client{},
 		accessToken: accessToken,
+		userAgent:   "rudder-api-go/1.0.0",
 	}
 
 	client.Sources = &sources{service: client.service("sources")}
@@ -69,7 +71,7 @@ func (c *Client) Do(ctx context.Context, method, path string, body io.Reader) ([
 	}
 
 	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("User-Agent", "terraform-provider-rudderstack/v0")
+	req.Header.Add("User-Agent", c.userAgent)
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.accessToken))
 
 	res, err := c.httpClient.Do(req)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,0 +1,22 @@
+package client_test
+
+import (
+	"testing"
+
+	"github.com/rudderlabs/rudder-api-go/client"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClientEmptyAccessToken(t *testing.T) {
+	_, err := client.New("")
+	assert.Equal(t, client.ErrEmptyAccessToken, err, "error should be ErrEmptyAccessToken")
+}
+
+func TestClientURL(t *testing.T) {
+	c, err := client.New("some-access-token")
+	assert.NoError(t, err)
+	assert.Equal(t, "https://api.rudderstack.com/v2", c.URL(""))
+	assert.Equal(t, "https://api.rudderstack.com/v2/path", c.URL("path"))
+	assert.Equal(t, "https://api.rudderstack.com/v2/path", c.URL("/path"))
+	assert.Equal(t, "https://api.rudderstack.com/v2/path/more", c.URL("/path/more"))
+}

--- a/client/common.go
+++ b/client/common.go
@@ -1,0 +1,23 @@
+package client
+
+import "encoding/json"
+
+type Paging struct {
+	Total int    `json:"total"`
+	Next  string `json:"next"`
+}
+
+type APIPage struct {
+	Paging Paging `json:"paging"`
+}
+
+type APIError struct {
+	HTTPStatusCode int
+	Message        string          `json:"error"`
+	ErrorCode      string          `json:"code"`
+	Details        json.RawMessage `json:"details"`
+}
+
+func (e *APIError) Error() string {
+	return e.Message
+}

--- a/client/destinations.go
+++ b/client/destinations.go
@@ -1,0 +1,83 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+)
+
+type Destination struct {
+	ID        string          `json:"id,omitempty"`
+	Name      string          `json:"name"`
+	Type      string          `json:"type"`
+	IsEnabled bool            `json:"enabled"`
+	Config    json.RawMessage `json:"config"`
+	CreatedAt *time.Time      `json:"createdAt,omitempty"`
+	UpdatedAt *time.Time      `json:"updatedAt,omitempty"`
+}
+
+type destinations struct {
+	*service
+}
+
+type DestinationsPage struct {
+	APIPage
+	Destinations []Destination `json:"destinations"`
+}
+
+func (s *destinations) Next(ctx context.Context, paging Paging) (*DestinationsPage, error) {
+	page := &DestinationsPage{}
+	ok, err := s.service.next(ctx, paging, page)
+	if !ok {
+		page = nil
+	}
+	return page, err
+}
+
+func (s *destinations) List(ctx context.Context) (*DestinationsPage, error) {
+	page := &DestinationsPage{}
+	if err := s.list(ctx, page); err != nil {
+		return nil, err
+	}
+
+	return page, nil
+}
+
+func (s *destinations) Get(ctx context.Context, id string) (*Destination, error) {
+	response := struct{ Destination *Destination }{}
+	if err := s.get(ctx, id, &response); err != nil {
+		return nil, err
+	}
+
+	return response.Destination, nil
+}
+
+func (s *destinations) Create(ctx context.Context, destination *Destination) (*Destination, error) {
+	// copy input and remove fields that should not be in request body without modifying input
+	src := *destination
+	src.ID = ""
+
+	response := struct{ Destination *Destination }{}
+	if err := s.create(ctx, &src, &response); err != nil {
+		return nil, err
+	}
+
+	return response.Destination, nil
+}
+
+func (s *destinations) Update(ctx context.Context, destination *Destination) (*Destination, error) {
+	// copy input and remove ID from request body without modifying input
+	dst := *destination
+	dst.ID = ""
+
+	response := struct{ Destination *Destination }{}
+	if err := s.update(ctx, destination.ID, &dst, &response); err != nil {
+		return nil, err
+	}
+
+	return response.Destination, nil
+}
+
+func (s *destinations) Delete(ctx context.Context, id string) error {
+	return s.service.delete(ctx, id)
+}

--- a/client/destinations_test.go
+++ b/client/destinations_test.go
@@ -1,0 +1,233 @@
+package client_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/rudderlabs/rudder-api-go/client"
+	"github.com/rudderlabs/rudder-api-go/internal/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientDestinationsList(t *testing.T) {
+	ctx := context.Background()
+
+	calls := []testutils.Call{
+		{
+			Method:         "GET",
+			URL:            "https://api.rudderstack.com/v2/destinations",
+			ResponseStatus: 200,
+			ResponseBody: `{
+				"destinations": [{
+					"id": "id-1",
+					"type": "type-1",
+					"name": "name-1",
+					"config": {"key":"val-1"}
+				},  {
+					"id": "id-2",
+					"type": "type-2",
+					"name": "name-2",
+					"config": {"key":"val-2"}
+				}],
+				"paging": {
+					"total": 3,
+					"next": "/destinations?page=2"
+				}
+			}`,
+		},
+		{
+			Method:         "GET",
+			URL:            "https://api.rudderstack.com/v2/destinations?page=2",
+			ResponseStatus: 200,
+			ResponseBody: `{
+				"destinations": [{
+					"id": "id-3",
+					"type": "type-3",
+					"name": "name-3",
+					"config": {"key":"val-3"}
+				}],
+				"paging": {
+					"total": 3
+				}
+			}`,
+		},
+	}
+
+	httpClient := testutils.NewMockHTTPClient(t, calls...)
+
+	c, err := client.New("some-access-token", client.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	page, err := c.Destinations.List(ctx)
+	require.NoError(t, err)
+	assert.NotNil(t, page)
+	assert.Len(t, page.Destinations, 2)
+	assert.Equal(t, client.Destination{ID: "id-1", Type: "type-1", Name: "name-1", Config: []byte(`{"key":"val-1"}`)}, page.Destinations[0])
+	assert.Equal(t, client.Destination{ID: "id-2", Type: "type-2", Name: "name-2", Config: []byte(`{"key":"val-2"}`)}, page.Destinations[1])
+	assert.Equal(t, 3, page.Paging.Total)
+	assert.Equal(t, "/destinations?page=2", page.Paging.Next)
+
+	page, err = c.Destinations.Next(ctx, page.Paging)
+	require.NoError(t, err)
+	assert.NotNil(t, page)
+	assert.Len(t, page.Destinations, 1)
+	assert.Equal(t, client.Destination{ID: "id-3", Type: "type-3", Name: "name-3", Config: []byte(`{"key":"val-3"}`)}, page.Destinations[0])
+	assert.Equal(t, 3, page.Paging.Total)
+	assert.Equal(t, "", page.Paging.Next)
+
+	page, err = c.Destinations.Next(ctx, page.Paging)
+	require.NoError(t, err)
+	assert.Nil(t, page)
+
+	httpClient.AssertNumberOfCalls()
+}
+
+func TestClientDestinationsGet(t *testing.T) {
+	ctx := context.Background()
+
+	calls := []testutils.Call{
+		{
+			Method:         "GET",
+			URL:            "https://api.rudderstack.com/v2/destinations/some-id",
+			ResponseStatus: 200,
+			ResponseBody: `{
+				"destination": {
+					"id": "some-id",
+					"name": "some-name",
+					"type": "some-type",
+					"config": {
+						"key1": "val1"
+					},
+					"createdAt": "2020-01-01T01:01:01Z",
+					"updatedAt": "2020-01-02T01:01:01Z"	
+				}
+			}`,
+		},
+	}
+
+	httpClient := testutils.NewMockHTTPClient(t, calls...)
+
+	c, err := client.New("some-access-token", client.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	destination, err := c.Destinations.Get(ctx, "some-id")
+	require.NoError(t, err)
+	assert.NotNil(t, destination)
+	assert.Equal(t, "some-id", destination.ID)
+	assert.Equal(t, "some-name", destination.Name)
+	assert.Equal(t, "some-type", destination.Type)
+	assert.Equal(t, time.Date(2020, 1, 1, 1, 1, 1, 0, time.UTC), *destination.CreatedAt)
+	assert.Equal(t, time.Date(2020, 1, 2, 1, 1, 1, 0, time.UTC), *destination.UpdatedAt)
+
+	httpClient.AssertNumberOfCalls()
+}
+
+func TestClientDestinationsCreate(t *testing.T) {
+	ctx := context.Background()
+
+	calls := []testutils.Call{
+		{
+			Method:         "POST",
+			URL:            "https://api.rudderstack.com/v2/destinations",
+			ResponseStatus: 200,
+			RequestBody: `{
+				"name": "some-name",
+				"type": "some-type",
+				"enabled": true,
+				"config": { "key1": "val1" }
+			}`,
+			ResponseBody: `{
+				"destination": {
+					"id": "some-id",
+					"name": "some-name",
+					"type": "some-type",
+					"config": {
+						"key1": "val1"
+					},
+					"createdAt": "2020-01-01T01:01:01Z",
+					"updatedAt": "2020-01-02T01:01:01Z"
+				}
+			}`,
+		},
+	}
+
+	httpClient := testutils.NewMockHTTPClient(t, calls...)
+
+	c, err := client.New("some-access-token", client.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	destination, err := c.Destinations.Create(ctx, &client.Destination{
+		Name:      "some-name",
+		Type:      "some-type",
+		IsEnabled: true,
+		Config: json.RawMessage([]byte(`{
+			"key1": "val1"
+		}`)),
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, destination)
+	assert.Equal(t, "some-id", destination.ID)
+	assert.Equal(t, "some-name", destination.Name)
+	assert.Equal(t, "some-type", destination.Type)
+	assert.Equal(t, time.Date(2020, 1, 1, 1, 1, 1, 0, time.UTC), *destination.CreatedAt)
+	assert.Equal(t, time.Date(2020, 1, 2, 1, 1, 1, 0, time.UTC), *destination.UpdatedAt)
+
+	httpClient.AssertNumberOfCalls()
+}
+
+func TestClientDestinationsUpdate(t *testing.T) {
+	ctx := context.Background()
+
+	calls := []testutils.Call{
+		{
+			Method:         "PUT",
+			URL:            "https://api.rudderstack.com/v2/destinations/some-id",
+			ResponseStatus: 200,
+			RequestBody: `{
+				"name": "some-name",
+			 	"type": "some-type",
+				"enabled": true,
+				"config": { "key1": "val1" }
+			}`,
+			ResponseBody: `{
+				"destination": {
+					"id": "some-id",
+					"name": "some-name",
+					"type": "some-type",
+					"config": {
+						"key1": "val1"
+					},
+					"createdAt": "2020-01-01T01:01:01Z",
+					"updatedAt": "2020-01-02T01:01:01Z"
+				}
+			}`,
+		},
+	}
+
+	httpClient := testutils.NewMockHTTPClient(t, calls...)
+
+	c, err := client.New("some-access-token", client.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	destination, err := c.Destinations.Update(ctx, &client.Destination{
+		ID:        "some-id",
+		Name:      "some-name",
+		Type:      "some-type",
+		IsEnabled: true,
+		Config: json.RawMessage([]byte(`{
+			"key1": "val1"
+		}`)),
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, destination)
+	assert.Equal(t, "some-id", destination.ID)
+	assert.Equal(t, "some-name", destination.Name)
+	assert.Equal(t, "some-type", destination.Type)
+	assert.Equal(t, time.Date(2020, 1, 1, 1, 1, 1, 0, time.UTC), *destination.CreatedAt)
+	assert.Equal(t, time.Date(2020, 1, 2, 1, 1, 1, 0, time.UTC), *destination.UpdatedAt)
+
+	httpClient.AssertNumberOfCalls()
+}

--- a/client/destinations_test.go
+++ b/client/destinations_test.go
@@ -3,6 +3,7 @@ package client_test
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"testing"
 	"time"
 
@@ -17,8 +18,9 @@ func TestClientDestinationsList(t *testing.T) {
 
 	calls := []testutils.Call{
 		{
-			Method:         "GET",
-			URL:            "https://api.rudderstack.com/v2/destinations",
+			Validate: func(req *http.Request) bool {
+				return testutils.ValidateRequest(t, req, "GET", "https://api.rudderstack.com/v2/destinations", "")
+			},
 			ResponseStatus: 200,
 			ResponseBody: `{
 				"destinations": [{
@@ -39,8 +41,9 @@ func TestClientDestinationsList(t *testing.T) {
 			}`,
 		},
 		{
-			Method:         "GET",
-			URL:            "https://api.rudderstack.com/v2/destinations?page=2",
+			Validate: func(req *http.Request) bool {
+				return testutils.ValidateRequest(t, req, "GET", "https://api.rudderstack.com/v2/destinations?page=2", "")
+			},
 			ResponseStatus: 200,
 			ResponseBody: `{
 				"destinations": [{
@@ -90,8 +93,9 @@ func TestClientDestinationsGet(t *testing.T) {
 
 	calls := []testutils.Call{
 		{
-			Method:         "GET",
-			URL:            "https://api.rudderstack.com/v2/destinations/some-id",
+			Validate: func(req *http.Request) bool {
+				return testutils.ValidateRequest(t, req, "GET", "https://api.rudderstack.com/v2/destinations/some-id", "")
+			},
 			ResponseStatus: 200,
 			ResponseBody: `{
 				"destination": {
@@ -130,15 +134,15 @@ func TestClientDestinationsCreate(t *testing.T) {
 
 	calls := []testutils.Call{
 		{
-			Method:         "POST",
-			URL:            "https://api.rudderstack.com/v2/destinations",
+			Validate: func(req *http.Request) bool {
+				return testutils.ValidateRequest(t, req, "POST", "https://api.rudderstack.com/v2/destinations", `{
+					"name": "some-name",
+					"type": "some-type",
+					"enabled": true,
+					"config": { "key1": "val1" }
+				}`)
+			},
 			ResponseStatus: 200,
-			RequestBody: `{
-				"name": "some-name",
-				"type": "some-type",
-				"enabled": true,
-				"config": { "key1": "val1" }
-			}`,
 			ResponseBody: `{
 				"destination": {
 					"id": "some-id",
@@ -183,15 +187,15 @@ func TestClientDestinationsUpdate(t *testing.T) {
 
 	calls := []testutils.Call{
 		{
-			Method:         "PUT",
-			URL:            "https://api.rudderstack.com/v2/destinations/some-id",
+			Validate: func(req *http.Request) bool {
+				return testutils.ValidateRequest(t, req, "PUT", "https://api.rudderstack.com/v2/destinations/some-id", `{
+					"name": "some-name",
+					"type": "some-type",
+					"enabled": true,
+					"config": { "key1": "val1" }
+				}`)
+			},
 			ResponseStatus: 200,
-			RequestBody: `{
-				"name": "some-name",
-			 	"type": "some-type",
-				"enabled": true,
-				"config": { "key1": "val1" }
-			}`,
 			ResponseBody: `{
 				"destination": {
 					"id": "some-id",

--- a/client/options.go
+++ b/client/options.go
@@ -1,0 +1,23 @@
+package client
+
+type Option func(*Client) error
+
+func WithBaseURL(baseURL string) Option {
+	return func(c *Client) error {
+		if baseURL == "" {
+			return ErrInvalidBaseURL
+		}
+		c.baseURL = baseURL
+		return nil
+	}
+}
+
+func WithHTTPClient(httpClient HTTPClient) Option {
+	return func(c *Client) error {
+		if httpClient == nil {
+			return ErrInvalidHTTPClient
+		}
+		c.httpClient = httpClient
+		return nil
+	}
+}

--- a/client/options.go
+++ b/client/options.go
@@ -21,3 +21,10 @@ func WithHTTPClient(httpClient HTTPClient) Option {
 		return nil
 	}
 }
+
+func WithUserAgent(userAgent string) Option {
+	return func(c *Client) error {
+		c.userAgent = userAgent
+		return nil
+	}
+}

--- a/client/options_test.go
+++ b/client/options_test.go
@@ -1,0 +1,46 @@
+package client_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rudderlabs/rudder-api-go/client"
+	"github.com/rudderlabs/rudder-api-go/internal/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientOptionBaseURL(t *testing.T) {
+	c, err := client.New("some-access-token", client.WithBaseURL("https://some-base-url"))
+	assert.NoError(t, err)
+	assert.Equal(t, "https://some-base-url/path", c.URL("path"))
+}
+
+func TestClientOptionBaseURLEmpty(t *testing.T) {
+	_, err := client.New("some-access-token", client.WithBaseURL(""))
+	assert.Error(t, err, client.ErrInvalidBaseURL)
+}
+
+func TestClientOptionHTTPClient(t *testing.T) {
+	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
+		Method:         "GET",
+		URL:            "https://example.com/path",
+		ResponseStatus: 200,
+		ResponseBody:   "test",
+	})
+
+	c, err := client.New("some-access-token",
+		client.WithBaseURL("https://example.com"),
+		client.WithHTTPClient(httpClient))
+	require.Nil(t, err)
+
+	res, err := c.Do(context.Background(), "GET", "path", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "test", string(res))
+	httpClient.AssertNumberOfCalls()
+}
+
+func TestClientOptionHTTPClientNil(t *testing.T) {
+	_, err := client.New("some-access-token", client.WithHTTPClient(nil))
+	assert.Equal(t, client.ErrInvalidHTTPClient, err)
+}

--- a/client/service.go
+++ b/client/service.go
@@ -1,0 +1,89 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+)
+
+type service struct {
+	basePath string
+	client   *Client
+}
+
+func (s *service) next(ctx context.Context, paging Paging, result interface{}) (bool, error) {
+	if paging.Next == "" {
+		return false, nil
+	}
+
+	res, err := s.client.Do(ctx, "GET", paging.Next, nil)
+	if err != nil {
+		return false, err
+	}
+
+	if err = json.Unmarshal(res, result); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+func (s *service) list(ctx context.Context, result interface{}) error {
+	_, err := s.next(ctx, Paging{Next: s.basePath}, result)
+	return err
+}
+
+func (s *service) get(ctx context.Context, id string, result interface{}) error {
+	res, err := s.client.Do(ctx, "GET", strings.Join([]string{s.basePath, id}, "/"), nil)
+	if err != nil {
+		return err
+	}
+
+	if err = json.Unmarshal(res, result); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *service) create(ctx context.Context, input interface{}, result interface{}) error {
+	body, err := json.Marshal(input)
+	if err != nil {
+		return err
+	}
+
+	res, err := s.client.Do(ctx, "POST", s.basePath, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+
+	if err = json.Unmarshal(res, result); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *service) update(ctx context.Context, id string, input interface{}, result interface{}) error {
+	body, err := json.Marshal(input)
+	if err != nil {
+		return err
+	}
+
+	res, err := s.client.Do(ctx, "PUT", strings.Join([]string{s.basePath, id}, "/"), bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+
+	if err = json.Unmarshal(res, result); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *service) delete(ctx context.Context, id string) error {
+	_, err := s.client.Do(ctx, "DELETE", strings.Join([]string{s.basePath, id}, "/"), nil)
+	return err
+}

--- a/client/sources.go
+++ b/client/sources.go
@@ -1,0 +1,85 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+)
+
+type Source struct {
+	ID        string          `json:"id,omitempty"`
+	Name      string          `json:"name"`
+	Type      string          `json:"type"`
+	WriteKey  string          `json:"writeKey,omitempty"`
+	IsEnabled bool            `json:"enabled"`
+	Config    json.RawMessage `json:"config"`
+	CreatedAt *time.Time      `json:"createdAt,omitempty"`
+	UpdatedAt *time.Time      `json:"updatedAt,omitempty"`
+}
+
+type sources struct {
+	*service
+}
+
+type SourcesPage struct {
+	APIPage
+	Sources []Source `json:"sources"`
+}
+
+func (s *sources) Next(ctx context.Context, paging Paging) (*SourcesPage, error) {
+	page := &SourcesPage{}
+	ok, err := s.service.next(ctx, paging, page)
+	if !ok {
+		page = nil
+	}
+	return page, err
+}
+
+func (s *sources) List(ctx context.Context) (*SourcesPage, error) {
+	page := &SourcesPage{}
+	if err := s.list(ctx, page); err != nil {
+		return nil, err
+	}
+
+	return page, nil
+}
+
+func (s *sources) Get(ctx context.Context, id string) (*Source, error) {
+	response := struct{ Source *Source }{}
+	if err := s.get(ctx, id, &response); err != nil {
+		return nil, err
+	}
+
+	return response.Source, nil
+}
+
+func (s *sources) Create(ctx context.Context, source *Source) (*Source, error) {
+	// copy input and remove fields that should not be in request body without modifying input
+	src := *source
+	src.ID = ""
+	src.WriteKey = ""
+
+	response := struct{ Source *Source }{}
+	if err := s.create(ctx, &src, &response); err != nil {
+		return nil, err
+	}
+
+	return response.Source, nil
+}
+
+func (s *sources) Update(ctx context.Context, source *Source) (*Source, error) {
+	// copy input and remove ID from request body without modifying input
+	src := *source
+	src.ID = ""
+
+	response := struct{ Source *Source }{}
+	if err := s.update(ctx, source.ID, &src, &response); err != nil {
+		return nil, err
+	}
+
+	return response.Source, nil
+}
+
+func (s *sources) Delete(ctx context.Context, id string) error {
+	return s.service.delete(ctx, id)
+}

--- a/client/sources_integration_test.go
+++ b/client/sources_integration_test.go
@@ -1,0 +1,34 @@
+//go:build integrationtest
+// +build integrationtest
+
+package client_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/rudderlabs/rudder-api-go/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newClient() (*client.Client, error) {
+	return client.New(os.Getenv("RUDDERSTACK_API_ACCESS_TOKEN"), client.WithBaseURL("http://localhost:5555/v2"))
+}
+
+func TestClientSourcesIntegration(t *testing.T) {
+	c, err := newClient()
+	require.NoError(t, err)
+
+	page, err := c.Sources.List(context.Background())
+	require.NoError(t, err)
+
+	assert.Len(t, page.Sources, 1)
+	j, _ := json.Marshal(page.Sources[0])
+	fmt.Printf("%v", string(j))
+	assert.Equal(t, 0, page.Paging.Total)
+	assert.Empty(t, page.Paging.Next)
+}

--- a/client/sources_test.go
+++ b/client/sources_test.go
@@ -1,0 +1,233 @@
+package client_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/rudderlabs/rudder-api-go/client"
+	"github.com/rudderlabs/rudder-api-go/internal/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientSourcesList(t *testing.T) {
+	ctx := context.Background()
+
+	calls := []testutils.Call{
+		{
+			Method:         "GET",
+			URL:            "https://api.rudderstack.com/v2/sources",
+			ResponseStatus: 200,
+			ResponseBody: `{
+				"sources": [{
+					"id": "id-1",
+					"type": "type-1",
+					"name": "name-1",
+					"config": {"key":"val-1"}
+				},  {
+					"id": "id-2",
+					"type": "type-2",
+					"name": "name-2",
+					"config": {"key":"val-2"}
+				}],
+				"paging": {
+					"total": 3,
+					"next": "/sources?page=2"
+				}
+			}`,
+		},
+		{
+			Method:         "GET",
+			URL:            "https://api.rudderstack.com/v2/sources?page=2",
+			ResponseStatus: 200,
+			ResponseBody: `{
+				"sources": [{
+					"id": "id-3",
+					"type": "type-3",
+					"name": "name-3",
+					"config": {"key":"val-3"}
+				}],
+				"paging": {
+					"total": 3
+				}
+			}`,
+		},
+	}
+
+	httpClient := testutils.NewMockHTTPClient(t, calls...)
+
+	c, err := client.New("some-access-token", client.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	page, err := c.Sources.List(ctx)
+	require.NoError(t, err)
+	assert.NotNil(t, page)
+	assert.Len(t, page.Sources, 2)
+	assert.Equal(t, client.Source{ID: "id-1", Type: "type-1", Name: "name-1", Config: []byte(`{"key":"val-1"}`)}, page.Sources[0])
+	assert.Equal(t, client.Source{ID: "id-2", Type: "type-2", Name: "name-2", Config: []byte(`{"key":"val-2"}`)}, page.Sources[1])
+	assert.Equal(t, 3, page.Paging.Total)
+	assert.Equal(t, "/sources?page=2", page.Paging.Next)
+
+	page, err = c.Sources.Next(ctx, page.Paging)
+	require.NoError(t, err)
+	assert.NotNil(t, page)
+	assert.Len(t, page.Sources, 1)
+	assert.Equal(t, client.Source{ID: "id-3", Type: "type-3", Name: "name-3", Config: []byte(`{"key":"val-3"}`)}, page.Sources[0])
+	assert.Equal(t, 3, page.Paging.Total)
+	assert.Equal(t, "", page.Paging.Next)
+
+	page, err = c.Sources.Next(ctx, page.Paging)
+	require.NoError(t, err)
+	assert.Nil(t, page)
+
+	httpClient.AssertNumberOfCalls()
+}
+
+func TestClientSourcesGet(t *testing.T) {
+	ctx := context.Background()
+
+	calls := []testutils.Call{
+		{
+			Method:         "GET",
+			URL:            "https://api.rudderstack.com/v2/sources/some-id",
+			ResponseStatus: 200,
+			ResponseBody: `{
+				"source": {
+					"id": "some-id",
+					"name": "some-name",
+					"type": "some-type",
+					"config": {
+						"key1": "val1"
+					},
+					"createdAt": "2020-01-01T01:01:01Z",
+					"updatedAt": "2020-01-02T01:01:01Z"	
+				}
+			}`,
+		},
+	}
+
+	httpClient := testutils.NewMockHTTPClient(t, calls...)
+
+	c, err := client.New("some-access-token", client.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	source, err := c.Sources.Get(ctx, "some-id")
+	require.NoError(t, err)
+	assert.NotNil(t, source)
+	assert.Equal(t, "some-id", source.ID)
+	assert.Equal(t, "some-name", source.Name)
+	assert.Equal(t, "some-type", source.Type)
+	assert.Equal(t, time.Date(2020, 1, 1, 1, 1, 1, 0, time.UTC), *source.CreatedAt)
+	assert.Equal(t, time.Date(2020, 1, 2, 1, 1, 1, 0, time.UTC), *source.UpdatedAt)
+
+	httpClient.AssertNumberOfCalls()
+}
+
+func TestClientSourcesCreate(t *testing.T) {
+	ctx := context.Background()
+
+	calls := []testutils.Call{
+		{
+			Method:         "POST",
+			URL:            "https://api.rudderstack.com/v2/sources",
+			ResponseStatus: 200,
+			RequestBody: `{
+				"name": "some-name",
+				"type": "some-type",
+				"enabled": true,
+				"config": { "key1": "val1" }
+			}`,
+			ResponseBody: `{
+				"source": {
+					"id": "some-id",
+					"name": "some-name",
+					"type": "some-type",
+					"config": {
+						"key1": "val1"
+					},
+					"createdAt": "2020-01-01T01:01:01Z",
+					"updatedAt": "2020-01-02T01:01:01Z"
+				}
+			}`,
+		},
+	}
+
+	httpClient := testutils.NewMockHTTPClient(t, calls...)
+
+	c, err := client.New("some-access-token", client.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	source, err := c.Sources.Create(ctx, &client.Source{
+		Name:      "some-name",
+		Type:      "some-type",
+		IsEnabled: true,
+		Config: json.RawMessage([]byte(`{
+			"key1": "val1"
+		}`)),
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, source)
+	assert.Equal(t, "some-id", source.ID)
+	assert.Equal(t, "some-name", source.Name)
+	assert.Equal(t, "some-type", source.Type)
+	assert.Equal(t, time.Date(2020, 1, 1, 1, 1, 1, 0, time.UTC), *source.CreatedAt)
+	assert.Equal(t, time.Date(2020, 1, 2, 1, 1, 1, 0, time.UTC), *source.UpdatedAt)
+
+	httpClient.AssertNumberOfCalls()
+}
+
+func TestClientSourcesUpdate(t *testing.T) {
+	ctx := context.Background()
+
+	calls := []testutils.Call{
+		{
+			Method:         "PUT",
+			URL:            "https://api.rudderstack.com/v2/sources/some-id",
+			ResponseStatus: 200,
+			RequestBody: `{
+				"name": "some-name",
+			 	"type": "some-type",
+				"enabled": true,
+				"config": { "key1": "val1" }
+			}`,
+			ResponseBody: `{
+				"source": {
+					"id": "some-id",
+					"name": "some-name",
+					"type": "some-type",
+					"config": {
+						"key1": "val1"
+					},
+					"createdAt": "2020-01-01T01:01:01Z",
+					"updatedAt": "2020-01-02T01:01:01Z"
+				}
+			}`,
+		},
+	}
+
+	httpClient := testutils.NewMockHTTPClient(t, calls...)
+
+	c, err := client.New("some-access-token", client.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	source, err := c.Sources.Update(ctx, &client.Source{
+		ID:        "some-id",
+		Name:      "some-name",
+		Type:      "some-type",
+		IsEnabled: true,
+		Config: json.RawMessage([]byte(`{
+			"key1": "val1"
+		}`)),
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, source)
+	assert.Equal(t, "some-id", source.ID)
+	assert.Equal(t, "some-name", source.Name)
+	assert.Equal(t, "some-type", source.Type)
+	assert.Equal(t, time.Date(2020, 1, 1, 1, 1, 1, 0, time.UTC), *source.CreatedAt)
+	assert.Equal(t, time.Date(2020, 1, 2, 1, 1, 1, 0, time.UTC), *source.UpdatedAt)
+
+	httpClient.AssertNumberOfCalls()
+}

--- a/client/sources_test.go
+++ b/client/sources_test.go
@@ -3,6 +3,7 @@ package client_test
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"testing"
 	"time"
 
@@ -17,8 +18,9 @@ func TestClientSourcesList(t *testing.T) {
 
 	calls := []testutils.Call{
 		{
-			Method:         "GET",
-			URL:            "https://api.rudderstack.com/v2/sources",
+			Validate: func(req *http.Request) bool {
+				return testutils.ValidateRequest(t, req, "GET", "https://api.rudderstack.com/v2/sources", "")
+			},
 			ResponseStatus: 200,
 			ResponseBody: `{
 				"sources": [{
@@ -39,8 +41,9 @@ func TestClientSourcesList(t *testing.T) {
 			}`,
 		},
 		{
-			Method:         "GET",
-			URL:            "https://api.rudderstack.com/v2/sources?page=2",
+			Validate: func(req *http.Request) bool {
+				return testutils.ValidateRequest(t, req, "GET", "https://api.rudderstack.com/v2/sources?page=2", "")
+			},
 			ResponseStatus: 200,
 			ResponseBody: `{
 				"sources": [{
@@ -90,8 +93,9 @@ func TestClientSourcesGet(t *testing.T) {
 
 	calls := []testutils.Call{
 		{
-			Method:         "GET",
-			URL:            "https://api.rudderstack.com/v2/sources/some-id",
+			Validate: func(req *http.Request) bool {
+				return testutils.ValidateRequest(t, req, "GET", "https://api.rudderstack.com/v2/sources/some-id", "")
+			},
 			ResponseStatus: 200,
 			ResponseBody: `{
 				"source": {
@@ -130,15 +134,15 @@ func TestClientSourcesCreate(t *testing.T) {
 
 	calls := []testutils.Call{
 		{
-			Method:         "POST",
-			URL:            "https://api.rudderstack.com/v2/sources",
+			Validate: func(req *http.Request) bool {
+				return testutils.ValidateRequest(t, req, "POST", "https://api.rudderstack.com/v2/sources", `{
+					"name": "some-name",
+					"type": "some-type",
+					"enabled": true,
+					"config": { "key1": "val1" }
+				}`)
+			},
 			ResponseStatus: 200,
-			RequestBody: `{
-				"name": "some-name",
-				"type": "some-type",
-				"enabled": true,
-				"config": { "key1": "val1" }
-			}`,
 			ResponseBody: `{
 				"source": {
 					"id": "some-id",
@@ -183,15 +187,15 @@ func TestClientSourcesUpdate(t *testing.T) {
 
 	calls := []testutils.Call{
 		{
-			Method:         "PUT",
-			URL:            "https://api.rudderstack.com/v2/sources/some-id",
+			Validate: func(req *http.Request) bool {
+				return testutils.ValidateRequest(t, req, "PUT", "https://api.rudderstack.com/v2/sources/some-id", `{
+					"name": "some-name",
+					"type": "some-type",
+					"enabled": true,
+					"config": { "key1": "val1" }
+				}`)
+			},
 			ResponseStatus: 200,
-			RequestBody: `{
-				"name": "some-name",
-			 	"type": "some-type",
-				"enabled": true,
-				"config": { "key1": "val1" }
-			}`,
 			ResponseBody: `{
 				"source": {
 					"id": "some-id",

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/rudderlabs/rudder-api-go
+
+go 1.17
+
+require github.com/stretchr/testify v1.7.0
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/testutils/mockhttp.go
+++ b/internal/testutils/mockhttp.go
@@ -1,0 +1,66 @@
+package testutils
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type Call struct {
+	Method         string
+	URL            string
+	RequestBody    string
+	ResponseStatus int
+	ResponseBody   string
+	ResponseError  error
+}
+
+type mockHTTPClient struct {
+	t         *testing.T
+	callIndex int
+	calls     []Call
+}
+
+func NewMockHTTPClient(t *testing.T, calls ...Call) *mockHTTPClient {
+	c := &mockHTTPClient{
+		t:     t,
+		calls: calls,
+	}
+
+	return c
+}
+
+func (c *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	if c.callIndex >= len(c.calls) {
+		err := fmt.Errorf("received unexpected request: %v", req)
+		c.t.Error(err)
+		return nil, err
+	}
+
+	call := c.calls[c.callIndex]
+	c.callIndex += 1
+
+	assert.Equal(c.t, call.Method, req.Method)
+	if call.RequestBody != "" {
+		body, err := ioutil.ReadAll(req.Body)
+		require.NoError(c.t, err)
+		assert.JSONEq(c.t, call.RequestBody, string(body))
+	}
+
+	return &http.Response{
+		StatusCode: call.ResponseStatus,
+		Body:       io.NopCloser(strings.NewReader(call.ResponseBody)),
+	}, call.ResponseError
+}
+
+func (c *mockHTTPClient) AssertNumberOfCalls() {
+	if c.callIndex < len(c.calls) {
+		c.t.Errorf("missing calls: expected %d, received %d", len(c.calls), c.callIndex)
+	}
+}


### PR DESCRIPTION
[Notion link](https://www.notion.so/rudderstacks/Rudder-API-Go-SDK-5b117f610a74498c8ee1c9c3bf64de2e)

Adds support for Sources/Destinations CRUD support. For an example on how the SDK is meant to be used, please check the README

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests for the code
- [x] I have made corresponding changes to the documentation
